### PR TITLE
Allow org,role,db,schema,store context to be set via DSN

### DIFF
--- a/src/conn.ts
+++ b/src/conn.ts
@@ -88,7 +88,23 @@ export class APIConnection implements StatementHandler, Connection {
       accessToken: tokenProvider,
     });
     this.api = new DeltastreamApi(config);
+
     this.rsctx = ResultSetContextFromJSON({});
+    if (url.searchParams.has('organizationID')) {
+      this.rsctx.organizationID = url.searchParams.get('organizationID')!;
+    }
+    if (url.searchParams.has('roleName')) {
+      this.rsctx.roleName = url.searchParams.get('roleName')!;
+    }
+    if (url.searchParams.has('databaseName')) {
+      this.rsctx.databaseName = url.searchParams.get('databaseName')!;
+    }
+    if (url.searchParams.has('schemaName')) {
+      this.rsctx.schemaName = url.searchParams.get('schemaName')!;
+    }
+    if (url.searchParams.has('storeName')) {
+      this.rsctx.storeName = url.searchParams.get('storeName')!;
+    }
   }
 
   async exec(query: string, attachments?: Blob[]): Promise<null> {


### PR DESCRIPTION
Allows an application to set the context via DSN. Context set in this way is not verified with server; i.e., queries willl error if current user does not have access to the resources set in the context in this manner.